### PR TITLE
what if babel-loader is an object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -112,14 +112,21 @@ TransformModulesPlugin.prototype.apply = function (compiler) {
           ]
         }
       }
-      jsConf.push({
-        loader: 'babel-loader',
-        options: {
-          plugins: [
-            ['babel-plugin-transform-modules', transformModules]
-          ]
-        }
-      })
+      // if babel-loader already exists,
+      // push babel-plugin-transform-modules into the plugins of existing babel-loader
+      if (typeof jsConf === 'object' && jsConf.loader === 'babel-loader') {
+        jsConf.plugins = jsConf.plugins || []
+        jsConf.plugins.push(['babel-plugin-transform-modules', transformModules])
+      } else {
+        jsConf.push({
+          loader: 'babel-loader',
+          options: {
+            plugins: [
+              ['babel-plugin-transform-modules', transformModules]
+            ]
+          }
+        })
+      }
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-transform-modules-plugin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "webpack transform modules plugin",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
if `babel-loader` already exists, and it's an `Object`,  push `babel-plugin-transform-modules` into the plugins of existing `babel-loader`

```javascript
if (typeof jsConf === 'object' && jsConf.loader === 'babel-loader') {
  jsConf.plugins = jsConf.plugins || []
  jsConf.plugins.push(['babel-plugin-transform-modules', transformModules])
} else {
  jsConf.push({
    loader: 'babel-loader',
    options: {
      plugins: [
        ['babel-plugin-transform-modules', transformModules]
      ]
    }
  })
}
```